### PR TITLE
Improved readability in dark mode

### DIFF
--- a/docs/_sass/dark-colours.scss
+++ b/docs/_sass/dark-colours.scss
@@ -3,8 +3,8 @@
 	--color0: hsl(0, 0%, 95%);
 	--color1: hsl(0, 0%, 75%);
 	--color2: hsl(0, 0%, 65%);
-	--layer0: hsl(0, 0%, 12%);
-	--layer1: hsla(0, 0%, 5%, 75%);
+	--layer0: hsl(0, 0%, 7%);
+	--layer1: hsla(0, 0%, 15%, 75%);
 	--layer2: hsl(0, 0%, 20%);
-	--transparent: 20%;
+	--transparent: 15%;
 }

--- a/docs/_sass/dark-colours.scss
+++ b/docs/_sass/dark-colours.scss
@@ -3,8 +3,8 @@
 	--color0: hsl(0, 0%, 95%);
 	--color1: hsl(0, 0%, 75%);
 	--color2: hsl(0, 0%, 65%);
-	--layer0: hsl(0, 0%, 0%);
-	--layer1: hsla(0, 0%, 10%, 75%);
+	--layer0: hsl(0, 0%, 12%);
+	--layer1: hsla(0, 0%, 5%, 75%);
 	--layer2: hsl(0, 0%, 20%);
 	--transparent: 20%;
 }


### PR DESCRIPTION
- Changed background colour (layer0) from pure black to dark grey when using dark mode to reduce eye strain.
- Slightly darkened layer1 to match with change in background.